### PR TITLE
Form ctrls aria describedby errors

### DIFF
--- a/ph-oton-bootstrap4/src/main/java/com/helger/photon/bootstrap4/form/BootstrapFormHelper.java
+++ b/ph-oton-bootstrap4/src/main/java/com/helger/photon/bootstrap4/form/BootstrapFormHelper.java
@@ -22,6 +22,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import com.helger.commons.collection.impl.ICommonsCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -141,9 +142,9 @@ public final class BootstrapFormHelper
     }
   }
 
-  public static void connectFormControlsWithErrors(@Nullable final Iterable <? extends  IHCElement <?>> aCtrls,
-                                              @Nullable final Iterable<? extends IHCElement<?>> aErrorNodes) {
-    if (aCtrls != null && aErrorNodes != null) {
+  public static void connectFormControlsWithErrors(@Nullable final ICommonsCollection <? extends  IHCElement <?>> aCtrls,
+                                              @Nullable final ICommonsCollection<? extends IHCElement<?>> aErrorNodes) {
+    if (aCtrls != null && aErrorNodes != null && aCtrls.isNotEmpty() &&aErrorNodes.isNotEmpty()) {
       for (final IHCElement <?> aCurCtrl : aCtrls)
       {
         aCurCtrl.customAttrs().setAriaDescribedBy(aErrorNodes);

--- a/ph-oton-bootstrap4/src/main/java/com/helger/photon/bootstrap4/form/BootstrapFormHelper.java
+++ b/ph-oton-bootstrap4/src/main/java/com/helger/photon/bootstrap4/form/BootstrapFormHelper.java
@@ -141,6 +141,16 @@ public final class BootstrapFormHelper
     }
   }
 
+  public static void connectFormControlsWithErrors(@Nullable final Iterable <? extends  IHCElement <?>> aCtrls,
+                                              @Nullable final Iterable<? extends IHCElement<?>> aErrorNodes) {
+    if (aCtrls != null && aErrorNodes != null) {
+      for (final IHCElement <?> aCurCtrl : aCtrls)
+      {
+        aCurCtrl.customAttrs().setAriaDescribedBy(aErrorNodes);
+      }
+    }
+  }
+
   public static void applyFormControlValidityState (@Nullable final IHCElement <?> aElement, @Nullable final IErrorList aErrorList)
   {
     ValueEnforcer.notNull (aElement, "Element");

--- a/ph-oton-bootstrap4/src/main/java/com/helger/photon/bootstrap4/form/DefaultBootstrapFormGroupRenderer.java
+++ b/ph-oton-bootstrap4/src/main/java/com/helger/photon/bootstrap4/form/DefaultBootstrapFormGroupRenderer.java
@@ -194,7 +194,7 @@ public class DefaultBootstrapFormGroupRenderer implements IBootstrapFormGroupRen
       aFirstControl = null;
 
     // Check form errors - highlighting
-    final CommonsArrayList<IHCElement<?>> aErrorCommonList = new CommonsArrayList<IHCElement<?>>();
+    final ICommonsList<IHCElement<?>> aErrorCommonList = new CommonsArrayList<IHCElement<?>>();
     if (aErrorList != null && aErrorList.isNotEmpty ())
     {
       for (final IError aError : aErrorList)
@@ -213,9 +213,7 @@ public class DefaultBootstrapFormGroupRenderer implements IBootstrapFormGroupRen
     BootstrapFormHelper.connectFormControlsWithErrors(aAllCtrls, aErrorCommonList);
 
     final HCNodeList aErrorListNode = new HCNodeList();
-    for (final IHCElement<?> aError : aErrorCommonList) {
-      aErrorListNode.addChild(aError);
-    }
+    aErrorListNode.addChildren(aErrorCommonList);
 
     // Help text (only if a control is present)
     IHCElement <?> aHelpTextNode = null;

--- a/ph-oton-bootstrap4/src/main/java/com/helger/photon/bootstrap4/form/DefaultBootstrapFormGroupRenderer.java
+++ b/ph-oton-bootstrap4/src/main/java/com/helger/photon/bootstrap4/form/DefaultBootstrapFormGroupRenderer.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import com.helger.commons.annotation.OverrideOnDemand;
+import com.helger.commons.collection.impl.CommonsArrayList;
 import com.helger.commons.collection.impl.ICommonsList;
 import com.helger.commons.error.IError;
 import com.helger.commons.error.list.IErrorList;
@@ -193,7 +194,7 @@ public class DefaultBootstrapFormGroupRenderer implements IBootstrapFormGroupRen
       aFirstControl = null;
 
     // Check form errors - highlighting
-    final HCNodeList aErrorListNode = new HCNodeList ();
+    final CommonsArrayList<IHCElement<?>> aErrorCommonList = new CommonsArrayList<IHCElement<?>>();
     if (aErrorList != null && aErrorList.isNotEmpty ())
     {
       for (final IError aError : aErrorList)
@@ -204,8 +205,16 @@ public class DefaultBootstrapFormGroupRenderer implements IBootstrapFormGroupRen
           // Enforce display!
           aErrorNode.addClass (CBootstrapCSS.D_BLOCK);
         }
-        aErrorListNode.addChild (aErrorNode);
+        aErrorCommonList.add (aErrorNode);
       }
+    }
+
+    // Set "aria-describedby"
+    BootstrapFormHelper.connectFormControlsWithErrors(aAllCtrls, aErrorCommonList);
+
+    final HCNodeList aErrorListNode = new HCNodeList();
+    for (final IHCElement<?> aError : aErrorCommonList) {
+      aErrorListNode.addChild(aError);
     }
 
     // Help text (only if a control is present)

--- a/ph-oton-html/src/main/java/com/helger/html/hc/html/IHCAttrContainer.java
+++ b/ph-oton-html/src/main/java/com/helger/html/hc/html/IHCAttrContainer.java
@@ -174,7 +174,7 @@ public interface IHCAttrContainer extends IAttributeContainer <IMicroQName, Stri
   }
 
   @Nonnull
-  default EChange setAriaDescribedBy (@Nonnull final ICommonsCollection <? extends IHCElement <?>> aDescribedByMultiple)
+  default EChange setAriaDescribedBy (@Nonnull final Iterable <? extends IHCElement <?>> aDescribedByMultiple)
   {
     return setAriaDescribedBy (StringHelper.imploder ()
                                            .source (aDescribedByMultiple, x -> x.ensureID ().getID ())
@@ -228,7 +228,7 @@ public interface IHCAttrContainer extends IAttributeContainer <IMicroQName, Stri
   }
 
   @Nonnull
-  default EChange setAriaLabeledBy (@Nonnull final ICommonsCollection <? extends IHCElement <?>> aLabeledByMultiple)
+  default EChange setAriaLabeledBy (@Nonnull final Iterable <? extends IHCElement <?>> aLabeledByMultiple)
   {
     return setAriaLabeledBy (StringHelper.imploder ().source (aLabeledByMultiple, x -> x.ensureID ().getID ()).separator (' ').build ());
   }


### PR DESCRIPTION
Hi!

Form error nodes aren't currently linked to their form controls. This pr adds `aria-describedby` with all form group errors to all form group controls.

I've also made `setAriaDescribedBy(...)` and `setAriaLabeledBy(...)` more generic 
by using `Iterable<? extends IHCElement<?>>` instead of `ICommonsCollection<? extends IHCElement<?>`

Edits or suggestions are very welcome.